### PR TITLE
fixes webpack "define cannot be used indirect".

### DIFF
--- a/PEGUtil.js
+++ b/PEGUtil.js
@@ -26,12 +26,12 @@
 (function (root, name, factory) {
     /* global define: false */
     /* global module: false */
-    if (typeof define === "function" && typeof define.amd !== "undefined")
-        /*  AMD environment  */
-        define(name, function () { return factory(root); });
-    else if (typeof module === "object" && typeof module.exports === "object")
+    if (typeof module === "object" && typeof module.exports === "object")
         /*  CommonJS environment  */
         module.exports = factory(root);
+    else if (typeof define === "function" && typeof define.amd !== "undefined")
+        /*  AMD environment  */
+        define(name, function () { return factory(root); });
     else
         /*  Browser environment  */
         root[name] = factory(root);


### PR DESCRIPTION
Hello Ralf,

I had a problem with pegjs-util UMD loader when trying to build my project using webpack, the build runs successfully but i get this error "define cannot be used indirect" in the runtime, i tried looking it up and found that it's a webpack issue, and that it won't be solved any soon.

I found that changing the preferences of the UMD loader solves the problem, so that it prefers CommonJS over AMD.

Thanks.